### PR TITLE
add CORS config for `/schema/manifest.json`

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -1,0 +1,2 @@
+/*
+  Access-Control-Allow-Origin: *

--- a/static/_headers
+++ b/static/_headers
@@ -1,2 +1,2 @@
-/*
+/schema/manifest.json
   Access-Control-Allow-Origin: *


### PR DESCRIPTION
Allow downloading the schema.json from localhost
see: https://answers.netlify.com/t/access-control-allow-origin-policy/1813/3


Fixes:
```
Access to fetch at 'https://www.topaz.sh/schema/manifest.json' from origin 'http://localhost:3000' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
```