### PR TITLE
update quickstart

### DIFF
--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -42,20 +42,19 @@ topaz install
 You can use the CLI to create a configuration file:
 
 ```shell
-topaz configure -n <policy-name> -d -s -r <resource-url>
+topaz configure -n <policy-name> -d -r <resource-url>
 ```
 
-For example, this command creates a configuration file for the sample Todo policy image.
+For example, this command creates a configuration file for the sample Todo **policy image**. A policy image is an OCI image that contains an OPA policy. The source code for the `ghcr.io/aserto-policies/policy-todo-rebac:latest` policy image can be found [here](https://github.com/aserto-templates/policy-todo-rebac/tree/main/content/src/policies).
 
 ```shell
-topaz configure -d -s -r ghcr.io/aserto-policies/policy-todo-rebac:latest -n policy-todo
+topaz configure -d -r ghcr.io/aserto-policies/policy-todo-rebac:latest -n todo
 ```
 
 The configuration file is generated in `$HOME/.config/topaz/cfg`.
 * the config instructs Topaz to create a local directory instance (`-d`)
-* when started, Topaz will seed the directory with default object types (`-s`)
-* the config references an authorization policy for a sample "Todo" app, retrieved from the Open Policy Registry as a container image
-* the config is named "policy-todo"
+* the config references an authorization policy for a sample "Todo" app, retrieved from GitHub Container Registry as a container image
+* the config is named "todo"
 
 For an in-depth look on the configuration section see [topaz config](https://github.com/aserto-dev/topaz/blob/main/docs/config.md)
 
@@ -111,6 +110,14 @@ curl -k -X POST 'https://localhost:8383/api/v2/authz/is' \
           "decisions": ["allowed"]
      }
 }'
+```
+
+### Bring up the console
+
+Topaz includes a built-in UI that lets you browse and interact with the model, data, and policy.
+
+```shell
+topaz console
 ```
 
 ## gRPC Endpoints


### PR DESCRIPTION
Fixed quickstart to remove the `-s` from `topaz configure`. Also did a bit of additional cleanup.
