### PR TITLE
updated quickstart to instal the todo template

### DIFF
--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -37,51 +37,64 @@ The Topaz authorizer is packaged as a Docker container. You can get the latest i
 topaz install
 ```
 
-### Create a configuration
+### Install the `todo` template
 
-You can use the CLI to create a configuration file:
+Topaz has a set of pre-built templates that contain three types of artifacts:
+* an authorization policy
+* a domain model (in the form of a manifest file)
+* sample data (users, groups, objects, relationships)
 
-```shell
-topaz configure -n <policy-name> -d -r <resource-url>
-```
-
-For example, this command creates a configuration file for the sample Todo **policy image**. A policy image is an OCI image that contains an OPA policy. The source code for the `ghcr.io/aserto-policies/policy-todo-rebac:latest` policy image can be found [here](https://github.com/aserto-templates/policy-todo-rebac/tree/main/content/src/policies).
-
-```shell
-topaz configure -d -r ghcr.io/aserto-policies/policy-todo-rebac:latest -n todo
-```
-
-The configuration file is generated in `$HOME/.config/topaz/cfg`.
-* the config instructs Topaz to create a local directory instance (`-d`)
-* the config references an authorization policy for a sample "Todo" app, retrieved from GitHub Container Registry as a container image
-* the config is named "todo"
-
-For an in-depth look on the configuration section see [topaz config](https://github.com/aserto-dev/topaz/blob/main/docs/config.md)
-
-### Start Topaz in interactive mode
+You can use the CLI to install the todo template:
 
 ```shell
-topaz run
+topaz templates install todo
 ```
 
-### Import sample data
+#### Artifacts
 
-Once Topaz is running, you can load user data into the database using the [Topaz CLI](/docs/command-line-interface/topaz-cli/index.mdx).
-
-The CLI contains commands to create schema and import data. In this quickstart we'll import the users, groups, and relationships for the Todo sample app.
-
-First, retrieve the "Citadel" json files, placing them in the current directory:
+This command will install the following artifacts in `$HOME/.config/topaz/`:
 
 ```shell
-curl https://raw.githubusercontent.com/aserto-dev/topaz/main/assets/citadel/citadel_objects.json >./citadel_objects.json
-curl https://raw.githubusercontent.com/aserto-dev/topaz/main/assets/citadel/citadel_relations.json >./citadel_relations.json
+tree $HOME/.config/topaz
+/Users/ogazitt/.config/topaz
+├── certs
+│   ├── gateway-ca.crt
+│   ├── gateway.crt
+│   ├── gateway.key
+│   ├── grpc-ca.crt
+│   ├── grpc.crt
+│   └── grpc.key
+├── cfg
+│   └── config.yaml
+├── data
+│   ├── citadel_objects.json
+│   └── citadel_relations.json
+├── db
+│   └── directory.db
+└── model
+    └── manifest.yaml
 ```
 
-Import the contents of the file into Topaz directory. This creates the sample users (Rick, Morty, and friends); groups; and relations.
+* `certs/` contains a set of generated self-signed certificates for Topaz.
+* `cfg/config.yaml` contains a Topaz configuration file which references the sample Todo **policy image**. A policy image is an OCI image that contains an OPA policy. For the Todo template, this is the public GHCR image `ghcr.io/aserto-policies/policy-todo-rebac:latest`. The source code for the policy image can be found [here](https://github.com/aserto-templates/policy-todo-rebac/tree/main/content/src/policies).
+* `data/` contains the objects and relations for the Todo template - in this case, a set of 5 users and 4 groups that are based on the "Rick & Morty" cartoon.
+* `db/directory.db` contains the embedded database which houses the model and data.
+* `model/manifest.yaml` contains the manifest file which describes the domain model.
 
-```shell
-topaz import -i -d .
-```
+:::tip
+For a deeper overview of the `cfg/config.yaml` file, see [topaz config](https://github.com/aserto-dev/topaz/blob/main/docs/config.md).
+:::
+
+#### What just happened?
+
+Besides laying down the artifacts mentioned, installing the Todo template did the following things:
+
+* started Topaz in daemon (background) mode (see `topaz start --help`).
+* set the manifest found in `model/manifest.yaml` (see `topaz set manifest --help`).
+* imported the objects and relations found in `data/` (see `topaz import --help`).
+* opened a browser window to the Topaz [console](https://localhost:8080/ui/directory) (see `topaz console --help`).
+
+Feel free to play around with the Topaz console! Or follow the next few steps to interact with the Topaz policy and authorization endpoints.
 
 ### Issue an API call
 
@@ -93,9 +106,9 @@ This API call retrieves the set of policies that Topaz has loaded:
 curl -k https://localhost:8383/api/v2/policies
 ```
 
-### Issue a query
+### Issue an authorization request
 
-Issue a query using the `is` REST API to verify that the user Rick is allowed to GET the list of todos:
+Issue an authorization request using the `is` REST API to verify that the user Rick is allowed to GET the list of todos:
 
 ```shell
 curl -k -X POST 'https://localhost:8383/api/v2/authz/is' \
@@ -112,17 +125,9 @@ curl -k -X POST 'https://localhost:8383/api/v2/authz/is' \
 }'
 ```
 
-### Bring up the console
-
-Topaz includes a built-in UI that lets you browse and interact with the model, data, and policy.
-
-```shell
-topaz console
-```
-
 ## gRPC Endpoints
 
-To interact with the authorizer endpoint, install `grpcui` or `grpcurl` and point them to `localhost:8282`:
+To interact with the authorizer endpoint over gRPC, install `grpcui` or `grpcurl` and point them to `localhost:8282`:
 
 ```shell
 grpcui --insecure localhost:8282
@@ -135,7 +140,8 @@ grpcui --insecure localhost:9292
 ```
 
 ## Next steps
-1. Review a sample app in your [favorite language](/docs/getting-started/samples)
-2. Create your own [policy](/docs/policies)
-3. Push your policy to a [registry](/docs/policies/lifecycle#policy-cli)
-4. Start Topaz by pointing it to your new policy with `topaz configure` and `topaz start`
+1. Clone and run the Todo sample backend in your [favorite language](/docs/getting-started/samples).
+2. Create your own directory [manifest](/docs/directory/define-domain-model).
+3. Create your own [policy](/docs/policies).
+4. Push your policy to a [registry](/docs/policies/lifecycle#policy-cli).
+5. Start Topaz by pointing it to your new policy with `topaz configure` and `topaz start`.


### PR DESCRIPTION
Our current quickstart has a missing step - setting the manifest. Rather than adding this step, I've reworked the quickstart instructions to simply install the `todo` template.
