### PR TITLE
removed last vestiges of policy-todo-rebac

### DIFF
--- a/docs/command-line-interface/topaz-cli/configuration.mdx
+++ b/docs/command-line-interface/topaz-cli/configuration.mdx
@@ -28,7 +28,7 @@ Example:
 To generate a configuration file for the demo "todo" policy using the public OCI image for that policy (from GHCR), use the following command:
 
 ```shell
-topaz configure -d -r ghcr.io/aserto-policies/policy-todo-rebac:latest -n todo
+topaz configure -d -r ghcr.io/aserto-policies/policy-todo:latest -n todo
 ```
 
 To generate a configuration file for a local OCI image, use the following command:

--- a/docs/getting-started/samples/index.mdx
+++ b/docs/getting-started/samples/index.mdx
@@ -9,7 +9,7 @@ To test Topaz with the policy for the Todo sample application, make sure you fol
 
 The configuration file in `$HOME/.config/topaz/cfg/config.yaml` should point to the policy image `ghcr.io/aserto-policies/policy-todo`.
 
-You can view the policy modules [here](https://github.com/aserto-templates/template-policy-todo/tree/main/content/src/policies).
+You can view the policy modules [here](https://github.com/aserto-templates/policy-todo/tree/main/content/src/policies).
 
 Continue setting up a server and a web application using your favorite language:
 


### PR DESCRIPTION
missed one

also, fixed the github repo for policy-todo to the correct repo.
