### PR TITLE
updates for topaz 0.32 syntax and config

### DIFF
--- a/docs/command-line-interface/topaz-cli/certs.mdx
+++ b/docs/command-line-interface/topaz-cli/certs.mdx
@@ -18,7 +18,7 @@ Example:
 ```
 topaz certs list
 
-certs directory: /home/<user>/.config/topaz/certs
+certs directory: /home/<user>/.local/share/topaz/certs
 
   FILE            NOT BEFORE            NOT AFTER             VALID  CN                DNS NAMES                  
   gateway-ca.crt  2024-03-11T11:30:19Z  2025-03-11T11:30:19Z  true   topaz-gateway-ca                             
@@ -32,7 +32,7 @@ certs directory: /home/<user>/.config/topaz/certs
 Allows adding/removing the generated development certs to the list of OS trusted certs. 
 
 ```
-Usage: topaz certs trust --certs-dir="/home/<user>/.config/topaz/certs"
+Usage: topaz certs trust --certs-dir="/home/<user>/.local/share/topaz/certs"
 
 trust/untrust dev certs
 
@@ -41,7 +41,7 @@ Flags:
   -N, --no-check                                      disable local container status check ($TOPAZ_NO_CHECK)
   -L, --log=0                                         log level
 
-      --certs-dir="/home/<user>/.config/topaz/certs"  path to dev certs folder
+      --certs-dir="/home/<user>/.local/share/topaz/certs"  path to dev certs folder
       --remove                                        remove dev cert from trust store
 ```
 
@@ -67,7 +67,7 @@ Flags:
   -N, --no-check                                      disable local container status check ($TOPAZ_NO_CHECK)
   -L, --log=0                                         log level
 
-      --certs-dir="/home/<user>/.config/topaz/certs"    path to dev certs folder
+      --certs-dir="/home/<user>/.local/share/topaz/certs"    path to dev certs folder
       --force                                         force generation of dev certs, overwriting existing cert files
       --trust                                         add generated certs to trust store
       --dns-names=localhost,...                       list of DNS names used to generate dev certs
@@ -81,7 +81,7 @@ If you use the `--trust` flag it will execute the `certs trust` command after ge
 Remove the development certs from the specified cert directory.
 
 ```
-Usage: topaz certs remove --certs-dir="/home/<user>/.config/topaz/certs"
+Usage: topaz certs remove --certs-dir="/home/<user>/.local/share/topaz/certs"
 
 remove dev certs
 
@@ -90,5 +90,5 @@ Flags:
   -N, --no-check                                      disable local container status check ($TOPAZ_NO_CHECK)
   -L, --log=0                                         log level
 
-      --certs-dir="/home/<user>/.config/topaz/certs"  path to dev certs folder
+      --certs-dir="/home/<user>/.local/share/topaz/certs"  path to dev certs folder
 ```

--- a/docs/command-line-interface/topaz-cli/configuration.mdx
+++ b/docs/command-line-interface/topaz-cli/configuration.mdx
@@ -71,7 +71,7 @@ Topaz CLI allows the user to have multiple configuration files and easily switch
 
 When using templates the generated configuration file uses the name of the template (ex. for `todo` template it will generate a `$XDG_CONFIG_HOME/topaz/cfg/todo.yaml`).
 
-To see available configuration files you can use the `topaz list` command, this will also highlight the current active configuration file. 
+To see available configuration files you can use the `topaz config list` command, this will also highlight the current active configuration file. 
 
 If you want to start topaz with a different configuration file, you can just specify the name of the configuration you want to use in the `topaz start/run -n=<name_of_configuration>` command. This will automatically switch you active configuration file to the one you used.
 
@@ -79,41 +79,34 @@ Note: The default `config.yaml` file will keep the container name as `topaz`. An
 
 ## Topaz CLI paths and environment variables
 
-By default the Topaz CLI uses XDG_CONFIG_HOME and XDG_DATA_HOME to store the topaz configuration files, local directory files and cert files.
+By default the Topaz CLI uses `XDG_CONFIG_HOME` and `XDG_DATA_HOME` to store the topaz configuration files, local directory files and cert files.
 These values can be easily overwritten using the Topaz specific environment variables TOPAZ_CERTS_DIR and TOPAZ_DB_DIR (used in newly generated configuration files).
 
 Depending on the OS if these are not set the default paths used are:
 
-1. Linux
-```
+1. Linux and Darwin/MacOS
+```sh
 - $HOME/.local/share/topaz/db - directory files
 - $HOME/.local/share/topaz/certs - cert files
 - $HOME/.config/topaz/cfg - config files
 ```
 
-2. Darwin
-```
-- $HOME/Library/Application Support/topaz/db - directory files
-- $HOME/Library/Application Support/topaz/certs - cert files
-- $HOME/Library/Application Support/topaz/cfg - config files
-```
-
-3. Windows
-```
+2. Windows
+```sh
 - $HOME\AppData\Local\topaz\certs - cert files
 - $HOME\AppData\Local\topaz\db - directory files
-- $HOME\AppData\Local\topaz\cfg - config files
+- $HOME\.config\topaz\cfg - config files
 ```
 
-If you used previous versions of topaz your configuration, database and cert files were stored in $HOME/.config/topaz
+If you used previous versions of Topaz, your configuration, database and cert files were stored in $HOME/.config/topaz
 If you want to keep using the same location to store your files with any newly generated configuration you can export
-``` 
+```sh
 export TOPAZ_CERTS_DIR=$HOME/.config/topaz/certs
 export TOPAZ_DB_DIR=$HOME/.config/topaz/db
 ```
 
 The topaz CLI could display the following warnings if you had older configuration setup:
-```
+```sh
 You still have old db files in /home/<user>/.config/topaz/db ! 
 Please see documentation on how to update your configuration: https://www.topaz.sh/docs/command-line-interface/topaz-cli/configuration
 ```
@@ -121,7 +114,7 @@ Please see documentation on how to update your configuration: https://www.topaz.
 In this scenario you still have database files in the location used by the previous versions of Topaz CLI. 
 To resolve this warning please move the files to the new location and update the matching configuration file or set the TOPAZ_DB_DIR environment variable as shown above.
 
-```
+```sh
 This configuration file still uses TOPAZ_DIR environment variable. Please change to using the new TOPAZ_DB_DIR and TOPAZ_CERTS_DIR environment variables.
 ```
 In this scenario you will need to update the configuration file to use the new TOPAZ_DB_DIR and TOPAZ_CERTS_DIR environment variables. 

--- a/docs/command-line-interface/topaz-cli/data.mdx
+++ b/docs/command-line-interface/topaz-cli/data.mdx
@@ -11,13 +11,13 @@ Topaz offers four commands to manage data (objects and relations):
 
 ## Importing objects and relations
 
-`topaz import` imports objects and relations in JSON format into the Topaz directory. It takes a directory argument and attempts to import all JSON files in that directory.
+`topaz directory import` imports objects and relations in JSON format into the Topaz directory. It takes a directory argument and attempts to import all JSON files in that directory.
 
 Example:
 
 ```shell
-topaz import -d .
->>> importing data from /Users/ogazitt/.config/topaz/data
+topaz directory import -d .
+>>> importing data from /Users/ogazitt/.local/share/topaz/todo/data
    object types skipped
     permissions skipped
  relation types skipped
@@ -44,6 +44,7 @@ Each file is a JSON object with an `objects` key or a `relations` key, which in 
     },
     ...
   ]
+}
 ```
 
 Note that each object must have a `type` key, and the value must be defined as one of the `types` in the manifest.  Each object also must have a unique `id` key (within the scope of that type). Finally, an object may have an optional `display_name` and an optional `properties` bag.
@@ -62,6 +63,7 @@ Note that each object must have a `type` key, and the value must be defined as o
     },
     ...
   ]
+}
 ```
 
 Note that each relation has at least five fields:
@@ -74,12 +76,12 @@ Note that each relation has at least five fields:
 
 ## Exporting objects and relations
 
-`topaz export` dumps the objects and relations into two files called `objects.json` and `relations.json`, in the directory specified with the `-d` option.
+`topaz directory export` dumps the objects and relations into two files called `objects.json` and `relations.json`, in the directory specified with the `-d` option.
 
 Example:
 
 ```shell
-topaz export -d . -i
+topaz directory export -d . -i
 >>> exporting data to .
    object types skipped
     permissions skipped
@@ -90,12 +92,12 @@ topaz export -d . -i
 
 ## Backing up a directory
 
-`topaz backup` creates a tarball with the objects.json and relations.json files. The file is named `backup.tar.gz` by default. To choose a different name, pass in the filename argument.
+`topaz directory backup` creates a tarball with the objects.json and relations.json files. The file is named `backup.tar.gz` by default. To choose a different name, pass in the filename argument.
 
 Example:
 
 ```shell
-topaz backup -i b.tar.gz
+topaz directory backup -i b.tar.gz
 >>> backup to b.tar.gz
    object types skipped
     permissions skipped
@@ -106,12 +108,12 @@ topaz backup -i b.tar.gz
 
 ## Restoring a directory from a backup
 
-`topaz restore` restores the directory data from a tarball named `backup.tar.gz` by default. To choose a different name, pass in the filename argument.
+`topaz directory restore` restores the directory data from a tarball named `backup.tar.gz` by default. To choose a different name, pass in the filename argument.
 
 Example:
 
 ```shell
-topaz restore  -i backup.tar.gz
+topaz directory restore  -i backup.tar.gz
 >>> restore from /tmp/new/backup.tar.gz
    object types skipped
     permissions skipped

--- a/docs/command-line-interface/topaz-cli/index.mdx
+++ b/docs/command-line-interface/topaz-cli/index.mdx
@@ -27,33 +27,31 @@
 
 ## Usage
 ```shell
-Usage: topaz <command>
+Usage: topaz <command> [flags]
 
 Topaz CLI
 
 Commands:
-  start        start topaz in daemon mode
-  stop         stop topaz instance
-  status       status of topaz daemon process
-  run          run topaz in console mode
-  manifest     manifest commands
-  test         test assertions commands
-  templates    template commands
-  console      open console in the browser
-  import       import directory objects
-  export       export directory objects
-  backup       backup directory data
-  restore      restore directory data
-  install      install topaz container
-  configure    configure topaz service
-  certs        cert commands
-  update       update topaz container version
-  uninstall    uninstall topaz container
-  version      version information
+  start              start topaz instance (daemon mode)
+  stop               stop topaz instance
+  restart            restart topaz instance
+  status             status of topaz daemon process
+  config             configure topaz instance
+  run                start topaz instance (console mode)
+  templates          template commands
+  console            open topaz console in the browser
+  directory (ds)     directory commands
+  authorizer (az)    authorizer commands
+  certs              certificate management
+  install            install topaz container
+  uninstall          uninstall topaz container
+  update             update topaz container version
+  version            version information
 
 Flags:
   -h, --help        Show context-sensitive help.
   -N, --no-check    disable local container status check ($TOPAZ_NO_CHECK)
+  -L, --log         log level
 
 Run "topaz <command> --help" for more information on a command.
 ```

--- a/docs/command-line-interface/topaz-cli/manifest.mdx
+++ b/docs/command-line-interface/topaz-cli/manifest.mdx
@@ -2,20 +2,18 @@
 
 Topaz offers three commands to manage the manifest:
 
-```shell
-  manifest get       get manifest
-  manifest set       set manifest
-  manifest delete    delete manifest
-```
+* `topaz directory get manifest`
+* `topaz directory set manifest`
+* `topaz directory delete manifest`
 
 ## Getting the manifest
 
-`topaz manifest get` retrieves the current manifest and prints it to stdout.
+`topaz directory get manifest` retrieves the current manifest and prints it to stdout.
 
 Example:
 
 ```shell
-topaz manifest get -i
+topaz directory get manifest -i
 >>> get manifest to
 # yaml-language-server: $schema=https://www.topaz.sh/schema/manifest.json
 ---
@@ -51,19 +49,19 @@ types:
 
 ## Setting a manifest
 
-`topaz manifest set` set the manifest from stdin. You can also specify a filename as an argument.
+`topaz directory set manifest` set the manifest from stdin. You can also specify a filename as an argument.
 
 Example:
 
 ```shell
-topaz manifest set -i ./manifest.yaml
->>> set manifest from /Users/ogazitt/.config/topaz/model/manifest.yaml
+topaz directory set manifest -i ./manifest.yaml
+>>> set manifest from /Users/ogazitt/.local/share/topaz/tmpl/todo/model/manifest.yaml
 ```
 
 ## Deleting the manifest
 
-`topaz manifest delete` removes the manifest and **deletes all data**. After deleting a manifest, you must set a new manifest before you can use the Topaz directory.
+`topaz directory delete manifest` removes the manifest and **deletes all data**. After deleting a manifest, you must set a new manifest before you can use the Topaz directory.
 
 :::note
-`topaz load` and `topaz save` have been deprecated in favor of `manifest set` and `manifest get`, respectively.
+`topaz directory load` and `topaz directory save` have been deprecated in favor of `topaz directory set manifest` and `topaz directory get manifest`, respectively.
 :::

--- a/docs/command-line-interface/topaz-cli/start.mdx
+++ b/docs/command-line-interface/topaz-cli/start.mdx
@@ -15,11 +15,11 @@ Topaz offers four commands to manage the running state of the Topaz daemon:
 
 ### Topazd container version
 
-To specify the container name and version that `topaz start` runs, use the following command-line options:
+To specify the container name and tag (version) that `topaz start` runs, use the following command-line options:
 
 ```shell
-      --container-name="topaz"        container name
-      --container-version="latest"    container version
+      --container-name="topaz"        container image name ($CONTAINER_IMAGE)
+      --container-tag="0.32.5"        container tag ($CONTAINER_TAG)
 ```
 
 ## Run

--- a/docs/command-line-interface/topaz-cli/templates.mdx
+++ b/docs/command-line-interface/topaz-cli/templates.mdx
@@ -38,9 +38,10 @@ topaz templates install todo
 Installing this template will completely reset your topaz configuration.
 Do you want to continue? (y/N) y
 >>> stopping topaz...
+>>> stopping topaz "todo"...
+>>> topaz is not running
 >>> configure policy
-
-certs directory: /Users/ogazitt/.config/topaz/certs
+certs directory: /Users/ogazitt/.local/share/topaz/certs
 
   FILE            ACTION
   gateway.crt     skipped, file already exists
@@ -50,27 +51,42 @@ certs directory: /Users/ogazitt/.config/topaz/certs
   grpc-ca.crt     skipped, file already exists
   grpc.key        skipped, file already exists
 policy name: todo
->>> starting topaz...
-db6ed35bede626edbc0692a30d9294b88e726f678ed96be9a5aa03117a08a5a7
+
+Using configuration "todo"
+>>> starting topaz "todo"...
+9dd5a0fc176980e9eb6ebf3587a3d6fcc9334c5cc4cb7182f4da52103736115b
+
 
 WARNING: delete manifest resets all directory state, including relation and object data
->>> delete manifest
->>> set manifest from /Users/ogazitt/.config/topaz/model/manifest.yaml
->>> importing data from /Users/ogazitt/.config/topaz/data
-   object types skipped
-    permissions skipped
- relation types skipped
-        objects 19
-      relations 20
+>>> delete manifest>>> set manifest to /Users/ogazitt/.local/share/topaz/tmpl/todo/model/manifest.yaml>>> importing data from /Users/ogazitt/.local/share/topaz/tmpl/todo/data
+        objects 20
+      relations 25
 ```
 
 ## Artifacts
 
-This command installs the following artifacts in `$HOME/.config/topaz/`:
+This command installs configuration artifacts in the Topaz configuration directory. To find out where this is, see [configuration](/docs/command-line-interface/topaz-cli/configuration.mdx). Unless you've set `$XDG_CONFIG_HOME`, this should be `$HOME/.config/topaz/`.
 
-```shell
+```sh
 tree $HOME/.config/topaz
 /Users/ogazitt/.config/topaz
+├── cfg
+│   └── todo.yaml
+└── topaz.json
+```
+
+* `cfg/todo.yaml` contains a Topaz configuration file which references the sample Todo **policy image**. A policy image is an OCI image that contains an OPA policy. For the Todo template, this is the public GHCR image `ghcr.io/aserto-policies/policy-todo:latest`. The source code for the policy image can be found [here](https://github.com/aserto-templates/policy-todo/tree/main/content/src/policies).
+* `topaz.json` contains all the installed configurations, as well as other topaz defaults.
+
+### Data and template artifacts
+
+The command also data and template artifacts in the Topaz data directory (`$XDG_DATA_HOME/topaz`), which defaults to `$HOME/.local/share/topaz` on Mac/Linux and `$HOME\AppData\Local\topaz` on Windows.
+
+When Topaz starts, it will also create certificates in a `certs` directory under this path.
+
+```shell
+tree $HOME/.local/share/topaz
+/Users/ogazitt/.local/share/topaz
 ├── certs
 │   ├── gateway-ca.crt
 │   ├── gateway.crt
@@ -78,30 +94,31 @@ tree $HOME/.config/topaz
 │   ├── grpc-ca.crt
 │   ├── grpc.crt
 │   └── grpc.key
-├── cfg
-│   └── config.yaml
-├── data
-│   ├── citadel_objects.json
-│   └── citadel_relations.json
 ├── db
-│   └── directory.db
-└── model
-    └── manifest.yaml
-```
+│   └── todo.db
+└── tmpl
+    └── todo
+        ├── data
+        │   ├── citadel_objects.json
+        │   ├── citadel_relations.json
+        │   ├── todo_objects.json
+        │   └── todo_relations.json
+        └── model
+            └── manifest.yaml
 
 * `certs/` contains a set of generated self-signed certificates for Topaz.
-* `cfg/config.yaml` contains a Topaz configuration file which references the sample Todo **policy image**. A policy image is an OCI image that contains an OPA policy. For the Todo template, this is the public GHCR image `ghcr.io/aserto-policies/policy-todo:latest`. The source code for the policy image can be found [here](https://github.com/aserto-templates/policy-todo/tree/main/content/src/policies).
-* `data/` contains the objects and relations for the Todo template - in this case, a set of 5 users and 4 groups that are based on the "Rick & Morty" cartoon.
-* `db/directory.db` contains the embedded database which houses the model and data.
-* `model/manifest.yaml` contains the manifest file which describes the domain model.
+that are based on the "Rick & Morty" cartoon.
+* `db/todo.db` contains the embedded database which houses the model and data.
+* `tmpl/todo/data/` contains the objects and relations that the template loads. The `citadel` files contain the users and groups associated with the "Citadel" demo IDP, and the `todo` files contain the template-specific objecs and relations.
+* `tmpl/todo/model/manifest.yaml` contains the directory manifest for the Todo template.
+
+Some templates also contain an `assertions/` subdirectory, which contains test cases for the model.
 
 ## Additional actions
 
 Besides laying down the artifacts mentioned, installing the Todo template invoked the following actions:
 
 * started Topaz in daemon (background) mode (see [starting Topaz](start)).
-* set the manifest found in `model/manifest.yaml` (see [setting the manifest](manifest#setting-a-manifest)).
-* imported the objects and relations found in `data/` (see [importing data](data#importing-objects-and-relations)).
+* set the manifest found in `tmpl/todo/model/manifest.yaml` (see [setting the manifest](manifest#setting-a-manifest)).
+* imported the objects and relations found in `tmpl/todo/data/` (see [importing data](data#importing-objects-and-relations)).
 * opened a browser window to the Topaz [console](https://localhost:8080/ui/directory) (see the [console](console)).
-
-

--- a/docs/command-line-interface/topaz-cli/test.mdx
+++ b/docs/command-line-interface/topaz-cli/test.mdx
@@ -6,35 +6,58 @@ Topaz makes it easy to define and run a set of test cases known as **assertions*
 
 Assertions are managed in a JSON file, by default named `assertions.json`.
 
-`topaz test template` emits a skeleton assertions file to stdout. 
-
-Example:
-
-```shell
-topaz test template
-{
-  "assertions": [
-	{"check": {"object_type": "", "object_id": "", "relation": "", "subject_type": "", "subject_id": ""}, "expected": true},
-	{"check_relation": {"object_type": "", "object_id": "", "relation": "", "subject_type": "", "subject_id": ""}, "expected": true},
-	{"check_permission": {"object_type": "", "object_id": "", "permission": "", "subject_type": "", "subject_id": ""}, "expected": true},
-	{"check_decision": {"identity_context": {"identity": "", "type": ""}, "resource_context": {}, "policy_context": {"path": "", "decisions": [""]}}, "expected":true},
-  ]
-}
-```
-
 There are two types of assertions:
-* `check`: define a test case that checks whether a `relation` (or permission) exists between an object (identified by `object_type` and `object_id`) and a subject (identified by `subject_type`, `subject_id`, and optionally `subject_relation`).
-* `check_decision`: define a test case that executes the authorizer `is` API over the given `identity_context`, `resource_context`, and `policy_context`
 
-Both types of assertions also include an `expected` key, which can be either `true` or `false` depending on whether the `check` is supposed to succeed or fail.
+- Directory assertions, or `check`: define a test case that checks whether a `relation` (or permission) exists between an object (identified by `object_type` and `object_id`) and a subject (identified by `subject_type`, `subject_id`, and optionally `subject_relation`).
+- Authorizer assertions, or `check_decision`: define a test case that executes the authorizer `is` API over the given `identity_context`, `resource_context`, and `policy_context`
+
+Both types of assertions also include an `expected` key, which can be either `true` or `false` depending on whether the assertion is supposed to succeed or fail.
 
 :::note
 The `check_relation` and `check_permission` are shown for backward-compatibility but are no longer used.
 :::
 
+### Directory assertions
+
+`topaz directory test template` emits a skeleton assertions file to stdout.
+
+Example:
+
+```shell
+topaz directory test template
+{
+  "assertions": [
+	{"check": {"object_type": "", "object_id": "", "relation": "", "subject_type": "", "subject_id": ""}, "expected": true},
+	{"check_relation": {"object_type": "", "object_id": "", "relation": "", "subject_type": "", "subject_id": ""}, "expected": true},
+	{"check_permission": {"object_type": "", "object_id": "", "permission": "", "subject_type": "", "subject_id": ""}, "expected": true},
+  ]
+}
+```
+
+:::note
+You should only use the `check` assertions. The `check_relation` and `check_permission` assertinos will be removed in a future release.
+:::
+
+### Authorizer assertions
+
+`topaz authorizer test template` emits a skeleton authorizer assertions file to stdout.
+
+Example:
+
+```shell
+topaz authorizer test template
+{
+  "assertions": [
+	{"check_decision": {"identity_context": {"identity": "", "type": ""}, "resource_context": {}, "policy_context": {"path": "", "decisions": [""]}}, "expected":true},
+  ]
+}
+```
+
 ## Running assertions
 
-`topaz test exec` executes the assertions in a JSON file of the proper format, defaulting to `./assertions.json`. To specify a different file name, use the filename argument. 
+### Directory assertions
+
+`topaz directory test exec` executes the assertions in a JSON file of the proper format, defaulting to `./assertions.json`. To specify a different file name, use the filename argument.
 
 Example:
 
@@ -42,39 +65,219 @@ Example:
 
 ```json
 {
-    "assertions": [
-        {"check":{"subject_type":"user","subject_id":"rick@the-citadel.com","relation":"member","object_type":"group","object_id":"admin"},"expected":true},
-        {"check":{"subject_type":"user","subject_id":"rick@the-citadel.com","relation":"member","object_type":"group","object_id":"evil_genius"},"expected":true},
-        {"check":{"subject_type":"user","subject_id":"rick@the-citadel.com","relation":"member","object_type":"group","object_id":"editor"},"expected":false},
-        {"check":{"subject_type":"user","subject_id":"rick@the-citadel.com","relation":"member","object_type":"group","object_id":"viewer"},"expected":false},
+  "assertions": [
+    {
+      "check": {
+        "subject_type": "user",
+        "subject_id": "rick@the-citadel.com",
+        "relation": "member",
+        "object_type": "group",
+        "object_id": "admin"
+      },
+      "expected": true
+    },
+    {
+      "check": {
+        "subject_type": "user",
+        "subject_id": "rick@the-citadel.com",
+        "relation": "member",
+        "object_type": "group",
+        "object_id": "evil_genius"
+      },
+      "expected": true
+    },
+    {
+      "check": {
+        "subject_type": "user",
+        "subject_id": "rick@the-citadel.com",
+        "relation": "member",
+        "object_type": "group",
+        "object_id": "editor"
+      },
+      "expected": false
+    },
+    {
+      "check": {
+        "subject_type": "user",
+        "subject_id": "rick@the-citadel.com",
+        "relation": "member",
+        "object_type": "group",
+        "object_id": "viewer"
+      },
+      "expected": false
+    },
 
-        {"check":{"subject_type":"user","subject_id":"morty@the-citadel.com","relation":"member","object_type":"group","object_id":"admin"},"expected":false},
-        {"check":{"subject_type":"user","subject_id":"morty@the-citadel.com","relation":"member","object_type":"group","object_id":"evil_genius"},"expected":false},
-        {"check":{"subject_type":"user","subject_id":"morty@the-citadel.com","relation":"member","object_type":"group","object_id":"editor"},"expected":true},
-        {"check":{"subject_type":"user","subject_id":"morty@the-citadel.com","relation":"member","object_type":"group","object_id":"viewer"},"expected":false},
-        
-        {"check":{"subject_type":"user","subject_id":"summer@the-smiths.com","relation":"member","object_type":"group","object_id":"admin"},"expected":false},
-        {"check":{"subject_type":"user","subject_id":"summer@the-smiths.com","relation":"member","object_type":"group","object_id":"evil_genius"},"expected":false},
-        {"check":{"subject_type":"user","subject_id":"summer@the-smiths.com","relation":"member","object_type":"group","object_id":"editor"},"expected":true},
-        {"check":{"subject_type":"user","subject_id":"summer@the-smiths.com","relation":"member","object_type":"group","object_id":"viewer"},"expected":false},
+    {
+      "check": {
+        "subject_type": "user",
+        "subject_id": "morty@the-citadel.com",
+        "relation": "member",
+        "object_type": "group",
+        "object_id": "admin"
+      },
+      "expected": false
+    },
+    {
+      "check": {
+        "subject_type": "user",
+        "subject_id": "morty@the-citadel.com",
+        "relation": "member",
+        "object_type": "group",
+        "object_id": "evil_genius"
+      },
+      "expected": false
+    },
+    {
+      "check": {
+        "subject_type": "user",
+        "subject_id": "morty@the-citadel.com",
+        "relation": "member",
+        "object_type": "group",
+        "object_id": "editor"
+      },
+      "expected": true
+    },
+    {
+      "check": {
+        "subject_type": "user",
+        "subject_id": "morty@the-citadel.com",
+        "relation": "member",
+        "object_type": "group",
+        "object_id": "viewer"
+      },
+      "expected": false
+    },
 
-        {"check":{"subject_type":"user","subject_id":"beth@the-smiths.com","relation":"member","object_type":"group","object_id":"admin"},"expected":false},
-        {"check":{"subject_type":"user","subject_id":"beth@the-smiths.com","relation":"member","object_type":"group","object_id":"evil_genius"},"expected":false},
-        {"check":{"subject_type":"user","subject_id":"beth@the-smiths.com","relation":"member","object_type":"group","object_id":"editor"},"expected":false},
-        {"check":{"subject_type":"user","subject_id":"beth@the-smiths.com","relation":"member","object_type":"group","object_id":"viewer"},"expected":true},
+    {
+      "check": {
+        "subject_type": "user",
+        "subject_id": "summer@the-smiths.com",
+        "relation": "member",
+        "object_type": "group",
+        "object_id": "admin"
+      },
+      "expected": false
+    },
+    {
+      "check": {
+        "subject_type": "user",
+        "subject_id": "summer@the-smiths.com",
+        "relation": "member",
+        "object_type": "group",
+        "object_id": "evil_genius"
+      },
+      "expected": false
+    },
+    {
+      "check": {
+        "subject_type": "user",
+        "subject_id": "summer@the-smiths.com",
+        "relation": "member",
+        "object_type": "group",
+        "object_id": "editor"
+      },
+      "expected": true
+    },
+    {
+      "check": {
+        "subject_type": "user",
+        "subject_id": "summer@the-smiths.com",
+        "relation": "member",
+        "object_type": "group",
+        "object_id": "viewer"
+      },
+      "expected": false
+    },
 
-        {"check":{"subject_type":"user","subject_id":"jerry@the-smiths.com","relation":"member","object_type":"group","object_id":"admin"},"expected":false},
-        {"check":{"subject_type":"user","subject_id":"jerry@the-smiths.com","relation":"member","object_type":"group","object_id":"evil_genius"},"expected":false},
-        {"check":{"subject_type":"user","subject_id":"jerry@the-smiths.com","relation":"member","object_type":"group","object_id":"editor"},"expected":false},
-        {"check":{"subject_type":"user","subject_id":"jerry@the-smiths.com","relation":"member","object_type":"group","object_id":"viewer"},"expected":true},
-    ]
+    {
+      "check": {
+        "subject_type": "user",
+        "subject_id": "beth@the-smiths.com",
+        "relation": "member",
+        "object_type": "group",
+        "object_id": "admin"
+      },
+      "expected": false
+    },
+    {
+      "check": {
+        "subject_type": "user",
+        "subject_id": "beth@the-smiths.com",
+        "relation": "member",
+        "object_type": "group",
+        "object_id": "evil_genius"
+      },
+      "expected": false
+    },
+    {
+      "check": {
+        "subject_type": "user",
+        "subject_id": "beth@the-smiths.com",
+        "relation": "member",
+        "object_type": "group",
+        "object_id": "editor"
+      },
+      "expected": false
+    },
+    {
+      "check": {
+        "subject_type": "user",
+        "subject_id": "beth@the-smiths.com",
+        "relation": "member",
+        "object_type": "group",
+        "object_id": "viewer"
+      },
+      "expected": true
+    },
+
+    {
+      "check": {
+        "subject_type": "user",
+        "subject_id": "jerry@the-smiths.com",
+        "relation": "member",
+        "object_type": "group",
+        "object_id": "admin"
+      },
+      "expected": false
+    },
+    {
+      "check": {
+        "subject_type": "user",
+        "subject_id": "jerry@the-smiths.com",
+        "relation": "member",
+        "object_type": "group",
+        "object_id": "evil_genius"
+      },
+      "expected": false
+    },
+    {
+      "check": {
+        "subject_type": "user",
+        "subject_id": "jerry@the-smiths.com",
+        "relation": "member",
+        "object_type": "group",
+        "object_id": "editor"
+      },
+      "expected": false
+    },
+    {
+      "check": {
+        "subject_type": "user",
+        "subject_id": "jerry@the-smiths.com",
+        "relation": "member",
+        "object_type": "group",
+        "object_id": "viewer"
+      },
+      "expected": true
+    }
+  ]
 }
 ```
 
 2. Run the test suite:
 
 ```shell
-topaz test exec -i
+topaz directory test exec -i
 0001 check            PASS  group:admin#member@user:rick@the-citadel.com [true] (2.764667ms)
 0002 check            PASS  group:evil_genius#member@user:rick@the-citadel.com [true] (1.545541ms)
 0003 check            PASS  group:editor#member@user:rick@the-citadel.com [false] (1.665166ms)
@@ -95,4 +298,61 @@ topaz test exec -i
 0018 check            PASS  group:evil_genius#member@user:jerry@the-smiths.com [false] (1.44825ms)
 0019 check            PASS  group:editor#member@user:jerry@the-smiths.com [false] (1.366709ms)
 0020 check            PASS  group:viewer#member@user:jerry@the-smiths.com [true] (1.349167ms)
+```
+
+### Authorizer assertions
+
+`topaz authorizer test exec` executes the assertions in a JSON file of the proper format, defaulting to `./assertions.json`. To specify a different file name, use the filename argument.
+
+Example:
+
+1. Create the following `assertions.json` file, which defines a set of test cases for the data in the `todo` template:
+
+```json
+{
+  "assertions": [
+    {
+      "check_decision": {
+        "identity_context": { "identity": "rick@the-citadel.com", "type": "IDENTITY_TYPE_SUB" },
+        "resource_context": {},
+        "policy_context": { "path": "todoApp.GET.todos", "decisions": ["allowed"] }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "identity_context": { "identity": "morty@the-citadel.com", "type": "IDENTITY_TYPE_SUB" },
+        "resource_context": { "object_type": "resource-creator", "object_id": "resource-creators", "relation": "member" },
+        "policy_context": { "path": "todoApp.POST.todos", "decisions": ["allowed"] }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "identity_context": { "identity": "jerry@the-smiths.com", "type": "IDENTITY_TYPE_SUB" },
+        "resource_context": {},
+        "policy_context": { "path": "todoApp.GET.todos", "decisions": ["allowed"] }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "identity_context": { "identity": "jerry@the-smiths.com", "type": "IDENTITY_TYPE_SUB" },
+        "resource_context": { "object_type": "resource-creator", "object_id": "resource-creators", "relation": "member" },
+        "policy_context": { "path": "todoApp.POST.todos", "decisions": ["allowed"] }
+      },
+      "expected": false
+    }
+  ]
+}
+```
+
+2. Run the test suite:
+
+```shell
+topaz authorizer test exec -i
+0001 check_decision   PASS  todoApp.GET.todos/allowed:rick@the-citadel.com [true] (65.22175ms)
+0002 check_decision   PASS  todoApp.POST.todos/allowed:morty@the-citadel.com [true] (3.702959ms)
+0003 check_decision   PASS  todoApp.GET.todos/allowed:jerry@the-smiths.com [true] (2.012125ms)
+0004 check_decision   PASS  todoApp.POST.todos/allowed:jerry@the-smiths.com [false] (2.7505ms)
 ```

--- a/docs/command-line-interface/topaz-cli/versioning.mdx
+++ b/docs/command-line-interface/topaz-cli/versioning.mdx
@@ -54,6 +54,13 @@ Note: currently there exists no support for running Topaz/Topazd on Windows runn
 Example:
 
 ```shell
-topaz 0.31.0 g9e4ac65 darwin-arm64 [2024-02-23T19:50:14Z]
-topazd 0.31.0
+topaz 0.32.5 g66b9f1a darwin-arm64 [2024-05-20T18:35:18Z]
+topazd 0.32.5
+```
+NOTE: when the matching container image version is not download yet, the following message will be returned:
+
+```shell
+topaz 0.32.5 g66b9f1a darwin-arm64 [2024-05-20T18:35:18Z]
+!!! container image "ghcr.io/aserto-dev/topaz:0.32.5" does not exist locally
+!!! run 'topaz install' to download
 ```

--- a/docs/deployment/amazon-ecs.mdx
+++ b/docs/deployment/amazon-ecs.mdx
@@ -10,7 +10,7 @@ The following is an example task definition for running topaz on Amazon ECS usin
 This example includes an `init-config` container that is responsible for retrieving a topaz config file from
 an S3 bucket before the `topaz` container starts up.
 
-The [topaz configure](/docs/command-line-interface/topaz-cli/configuration) CLI command can be used to generate
+The [topaz config new](/docs/command-line-interface/topaz-cli/configuration) CLI command can be used to generate
 your configuration file, then it should be uploaded to a bucket location that is accessible by the `init-config` container.
 
 This example attaches an EBS volume to persist the configuration, certs, and directory database.  If it does not already exist

--- a/docs/deployment/binary.mdx
+++ b/docs/deployment/binary.mdx
@@ -41,32 +41,18 @@ Archive:  topaz.zip
 
 ## Create a configuration file
 
-Topaz expects a configuration file  the `config.yaml` file to be in `$HOME/.config/topaz/cfg/config.yaml`. The configuration file can be created using the `topaz configure` command, documented [here](/docs/command-line-interface/topaz-cli/configuration.mdx).
+Topaz requires a configuration file in order to run. The configuration file can be created using the `topaz config new` command, documented [here](/docs/command-line-interface/topaz-cli/configuration.mdx). A configuration file is automatically created when you install a template, documented [here](/docs/command-line-interface/topaz-cli/templates.mdx).
 
-For example, to use the sample policy, you can run the following:
-
-```sh
-./topaz configure -d -r ghcr.io/aserto-policies/policy-todo:latest -n policy-todo
-```
-
-This will create a directory structure in `$HOME/.config/topaz` like this:
+For example, to use the sample todo policy, you can run the following:
 
 ```sh
-├──  certs
-│   ├──  gateway-ca.crt
-│   ├──  gateway.crt
-│   ├──  gateway.key
-│   ├──  grpc-ca.crt
-│   ├──  grpc.crt
-│   └──  grpc.key
-├──  cfg
-│   └──  config.yaml
-└──  db
-    └──  directory.db
+./topaz config new -d -r ghcr.io/aserto-policies/policy-todo:latest -n todo
 ```
+
+This will create a config file in `$HOME/.config/topaz/cfg/todo.yaml`.
 
 ## Run the topaz daemon
 
 ```sh
-TOPAZ_DIR=$HOME/.config/topaz ./topazd run -c $HOME/.config/topaz/cfg/config.yaml
+TOPAZ_DIR=$HOME/.config/topaz ./topazd run -c $HOME/.config/topaz/cfg/todo.yaml
 ```

--- a/docs/deployment/docker-compose.mdx
+++ b/docs/deployment/docker-compose.mdx
@@ -59,8 +59,8 @@ While topaz is running, from another terminal invoke the topaz CLI inside the ru
 
 ```sh
 cd topaz/docs/deployments/docker-compose
-docker compose exec topaz ./topaz manifest set --no-check -i /data/manifest.yaml
-docker compose exec topaz ./topaz import --no-check -i -H localhost:9292 -d /data
+docker compose exec topaz ./topaz directory set manifest --no-check -i /data/manifest.yaml
+docker compose exec topaz ./topaz directory import --no-check -i -H localhost:9292 -d /data
 ```
 
 A successful directory import should produce this output:

--- a/docs/deployment/microservice.mdx
+++ b/docs/deployment/microservice.mdx
@@ -30,7 +30,7 @@ ghcr.io/aserto-dev/topaz:latest run \
 --config-file /app/cfg/config.yaml
 ```
 
-Note that this command expects the `config.yaml` file to be in `$PWD/cfg/config.yaml`. The configuration file can be created using the `topaz configure` command, documented [here](/docs/command-line-interface/topaz-cli/configuration.mdx).
+Note that this command expects the `config.yaml` file to be in `$PWD/cfg/config.yaml`. The configuration file can be created using the `topaz config new` command, documented [here](/docs/command-line-interface/topaz-cli/configuration.mdx).
 
 # Browse to the console
 In a web browser, visit https://localhost:8080/ui/directory/model to access the web console.

--- a/docs/directory/creating-instances.mdx
+++ b/docs/directory/creating-instances.mdx
@@ -4,10 +4,10 @@ sidebar_position: 3
 
 # Creating instances
 
-To populate the database with some data from a JSON file, make sure `topaz` is running and then use the `topaz import` command:
+To populate the database with some data from a JSON file, make sure `topaz` is running and then use the `topaz directory import` command:
 
-```
-topaz import -i -d <directory containing JSON file>
+```sh
+topaz directory import -i -d <directory containing JSON file>
 ```
 
 The two JSON files should contain
@@ -111,6 +111,6 @@ Copy this block into `./relations.json`:
 
 Now run the following command to import the data:
 
-```
-topaz import -i -d .
+```sh
+topaz directory import -i -d .
 ```

--- a/docs/directory/define-domain-model.mdx
+++ b/docs/directory/define-domain-model.mdx
@@ -83,7 +83,7 @@ More information on operators can be found in the [Manifest Reference](./manifes
 Load the `manifest.yaml` file into Topaz by running:
 
 ```sh
-topaz manifest set ./manifest.yaml
+topaz directory set manifest ./manifest.yaml -i
 ```
 
 ## Manifest language reference

--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -71,11 +71,28 @@ topaz templates install todo
 
 #### Artifacts
 
-This command will install the following artifacts in `$HOME/.config/topaz/`:
+This command installs configuration artifacts in the Topaz configuration directory. To find out where this is, see [configuration](/docs/command-line-interface/topaz-cli/configuration.mdx). Unless you've set `$XDG_CONFIG_HOME`, this should be `$HOME/.config/topaz/`.
 
-```shell
+```sh
 tree $HOME/.config/topaz
 /Users/ogazitt/.config/topaz
+├── cfg
+│   └── todo.yaml
+└── topaz.json
+```
+
+* `cfg/todo.yaml` contains a Topaz configuration file which references the sample Todo **policy image**. A policy image is an OCI image that contains an OPA policy. For the Todo template, this is the public GHCR image `ghcr.io/aserto-policies/policy-todo:latest`. The source code for the policy image can be found [here](https://github.com/aserto-templates/policy-todo/tree/main/content/src/policies).
+* `topaz.json` contains all the installed configurations, as well as other Topaz defaults.
+
+##### Data and template artifacts
+
+The command also data and template artifacts in the Topaz data directory (`$XDG_DATA_HOME/topaz`), which defaults to `$HOME/.local/share/topaz` on Mac/Linux and `$HOME\AppData\Local\topaz` on Windows.
+
+When Topaz starts, it will also create certificates in a `certs` directory under this path.
+
+```shell
+tree $HOME/.local/share/topaz
+/Users/ogazitt/.local/share/topaz
 ├── certs
 │   ├── gateway-ca.crt
 │   ├── gateway.crt
@@ -83,22 +100,23 @@ tree $HOME/.config/topaz
 │   ├── grpc-ca.crt
 │   ├── grpc.crt
 │   └── grpc.key
-├── cfg
-│   └── config.yaml
-├── data
-│   ├── citadel_objects.json
-│   └── citadel_relations.json
 ├── db
-│   └── directory.db
-└── model
-    └── manifest.yaml
-```
+│   └── todo.db
+└── tmpl
+    └── todo
+        ├── data
+        │   ├── citadel_objects.json
+        │   ├── citadel_relations.json
+        │   ├── todo_objects.json
+        │   └── todo_relations.json
+        └── model
+            └── manifest.yaml
 
 * `certs/` contains a set of generated self-signed certificates for Topaz.
-* `cfg/config.yaml` contains a Topaz configuration file which references the sample Todo **policy image**. A policy image is an OCI image that contains an OPA policy. For the Todo template, this is the public GHCR image `ghcr.io/aserto-policies/policy-todo:latest`. The source code for the policy image can be found [here](https://github.com/aserto-templates/policy-todo/tree/main/content/src/policies).
-* `data/` contains the objects and relations for the Todo template - in this case, a set of 5 users and 4 groups that are based on the "Rick & Morty" cartoon.
-* `db/directory.db` contains the embedded database which houses the model and data.
-* `model/manifest.yaml` contains the manifest file which describes the domain model.
+that are based on the "Rick & Morty" cartoon.
+* `db/todo.db` contains the embedded database which houses the model and data.
+* `tmpl/todo/data/` contains the objects and relations that the template loads. The `citadel` files contain the users and groups associated with the "Citadel" demo IDP, and the `todo` files contain the template-specific objecs and relations.
+* `tmpl/todo/model/manifest.yaml` contains the directory manifest for the Todo template.
 
 :::tip
 For a deeper overview of the `cfg/config.yaml` file, see [topaz config](https://github.com/aserto-dev/topaz/blob/main/docs/config.md).
@@ -109,8 +127,8 @@ For a deeper overview of the `cfg/config.yaml` file, see [topaz config](https://
 Besides laying down the artifacts mentioned, installing the Todo template did the following things:
 
 * started Topaz in daemon (background) mode (see `topaz start --help`).
-* set the manifest found in `model/manifest.yaml` (see `topaz set manifest --help`).
-* imported the objects and relations found in `data/` (see `topaz import --help`).
+* set the manifest found in `tmpl/todo/model/manifest.yaml` (see `topaz directory set manifest --help`).
+* imported the objects and relations found in `tmpl/todo/data/` (see `topaz directory import --help`).
 * opened a browser window to the Topaz [console](https://localhost:8080/ui/directory) (see `topaz console --help`).
 
 Feel free to play around with the Topaz console! Or follow the next few steps to interact with the Topaz policy and authorization endpoints.
@@ -127,7 +145,9 @@ curl -k https://localhost:8383/api/v2/policies
 
 ### Issue an authorization request
 
-Issue an authorization request using the `is` REST API to verify that the user Rick is allowed to GET the list of todos:
+Issue an authorization request using the `is` REST API to verify that the user Rick is allowed to GET the list of todos.
+
+#### As a curl
 
 ```shell
 curl -k -X POST 'https://localhost:8383/api/v2/authz/is' \
@@ -142,6 +162,21 @@ curl -k -X POST 'https://localhost:8383/api/v2/authz/is' \
           "decisions": ["allowed"]
      }
 }'
+```
+
+#### Using the topaz CLI
+
+```shell
+topaz authorizer eval '{
+     "identity_context": {
+          "type": "IDENTITY_TYPE_SUB",
+          "identity": "rick@the-citadel.com"
+     },
+     "policy_context": {
+          "path": "todoApp.GET.todos",
+          "decisions": ["allowed"]
+     }
+}' -i
 ```
 
 ## gRPC Endpoints
@@ -163,4 +198,4 @@ grpcui --insecure localhost:9292
 2. Create your own directory [manifest](/docs/directory/define-domain-model).
 3. Create your own [policy](/docs/policies).
 4. Push your policy to a [registry](/docs/policies/lifecycle#policy-cli).
-5. Start Topaz by pointing it to your new policy with `topaz configure` and `topaz start`.
+5. Start Topaz by pointing it to your new policy with `topaz config new` and `topaz start`.

--- a/docs/getting-started/samples/flask.mdx
+++ b/docs/getting-started/samples/flask.mdx
@@ -19,7 +19,7 @@ pipenv install
 ```
 
 ### Set up the `.env` file
-Copy the `.env.example` file to `.env` and update the `ASERTO_AUTHORIZER_CERT_PATH` and `ASERTO_DIRECTORY_GRPC_CERT_PATH` to correspond to the path in which Topaz generated your certificates (by default this path will be `$HOME/.config/topaz/certs/grpc-ca.crt`).
+Copy the `.env.example` file to `.env` and update the `ASERTO_AUTHORIZER_CERT_PATH` and `ASERTO_DIRECTORY_GRPC_CERT_PATH` to correspond to the path in which Topaz generated your certificates (by default this path will be `$HOME/.local/share/topaz/certs/grpc-ca.crt`, or `$HOME\AppData\Local\topaz\certs` on Windows).
 
 ```bash
 cp .env.example .env
@@ -35,9 +35,9 @@ AUDIENCE=citadel-app
 ASERTO_POLICY_ROOT="todoApp"
 
 ASERTO_AUTHORIZER_SERVICE_URL=localhost:8282
-ASERTO_AUTHORIZER_CERT_PATH=$HOME/.config/topaz/certs/grpc-ca.crt
+ASERTO_AUTHORIZER_CERT_PATH=$HOME/.local/share/topaz/certs/grpc-ca.crt
 ASERTO_DIRECTORY_SERVICE_URL=localhost:9292
-ASERTO_DIRECTORY_GRPC_CERT_PATH=$HOME/.config/topaz/certs/grpc-ca.crt
+ASERTO_DIRECTORY_GRPC_CERT_PATH=$HOME/.local/share/topaz/certs/grpc-ca.crt
 ```
 
 ## Start the server

--- a/docs/getting-started/samples/go.mdx
+++ b/docs/getting-started/samples/go.mdx
@@ -9,7 +9,7 @@ git clone https://github.com/aserto-demo/todo-go-v2
 ```
 
 ## Set up an `.env` file
-Copy the `.env.example` file to `.env` and update the `ASERTO_AUTHORIZER_CERT_PATH` and `ASERTO_DIRECTORY_GRPC_CERT_PATH` to correspond to the path in which Topaz generated your certificates (by default this path will be `$HOME/.config/topaz/certs/grpc-ca.crt`).
+Copy the `.env.example` file to `.env` and update the `ASERTO_AUTHORIZER_CERT_PATH` and `ASERTO_DIRECTORY_GRPC_CERT_PATH` to correspond to the path in which Topaz generated your certificates (by default this path will be `$HOME/.local/share/topaz/certs/grpc-ca.crt`, or `$HOME\AppData\Local\topaz\certs` on Windows).
 
 ```bash
 cp .env.example .env
@@ -25,9 +25,9 @@ AUDIENCE=citadel-app
 ASERTO_POLICY_ROOT="todoApp"
 
 ASERTO_AUTHORIZER_SERVICE_URL=localhost:8282
-ASERTO_AUTHORIZER_CERT_PATH=$HOME/.config/topaz/certs/grpc-ca.crt
+ASERTO_AUTHORIZER_CERT_PATH=$HOME/.local/share/topaz/certs/grpc-ca.crt
 ASERTO_DIRECTORY_SERVICE_URL=localhost:9292
-ASERTO_DIRECTORY_GRPC_CERT_PATH=$HOME/.config/topaz/certs/grpc-ca.crt
+ASERTO_DIRECTORY_GRPC_CERT_PATH=$HOME/.local/share/topaz/certs/grpc-ca.crt
 ```
 
 ### Install dependencies

--- a/docs/getting-started/samples/index.mdx
+++ b/docs/getting-started/samples/index.mdx
@@ -7,7 +7,7 @@ import LanguagesList from '../../../src/components/LanguagesList'
 
 To test Topaz with the policy for the Todo sample application, make sure you follow the instructions in the [previous section](/docs/getting-started/index.mdx) to properly install and configure Topaz.
 
-The configuration file in `$HOME/.config/topaz/cfg/config.yaml` should point to the policy image `ghcr.io/aserto-policies/policy-todo`.
+The configuration file in `$HOME/.config/topaz/cfg/todo.yaml` should point to the policy image `ghcr.io/aserto-policies/policy-todo`.
 
 You can view the policy modules [here](https://github.com/aserto-templates/policy-todo/tree/main/content/src/policies).
 

--- a/docs/getting-started/samples/java.mdx
+++ b/docs/getting-started/samples/java.mdx
@@ -9,7 +9,7 @@ git clone https://github.com/aserto-demo/todo-java-v2
 ```
 
 ## Set up an `.env` file
-Copy the `.env.example` file to `.env` and update the `ASERTO_AUTHORIZER_CERT_PATH` and `ASERTO_DIRECTORY_GRPC_CERT_PATH` to correspond to the path in which Topaz generated your certificates (by default this path will be `$HOME/.config/topaz/certs/grpc-ca.crt`).
+Copy the `.env.example` file to `.env` and update the `ASERTO_AUTHORIZER_CERT_PATH` and `ASERTO_DIRECTORY_GRPC_CERT_PATH` to correspond to the path in which Topaz generated your certificates (by default this path will be `$HOME/.local/share/topaz/certs/grpc-ca.crt`, or `$HOME\AppData\Local\topaz\certs` on Windows).
 
 ```bash
 cp .env.example .env
@@ -25,9 +25,9 @@ AUDIENCE=citadel-app
 ASERTO_POLICY_ROOT="todoApp"
 
 ASERTO_AUTHORIZER_SERVICE_URL=localhost:8282
-ASERTO_AUTHORIZER_CERT_PATH='$HOME/.config/topaz/certs/grpc-ca.crt'
+ASERTO_AUTHORIZER_CERT_PATH='$HOME/.local/share/topaz/certs/grpc-ca.crt'
 ASERTO_DIRECTORY_SERVICE_URL=localhost:9292
-ASERTO_DIRECTORY_GRPC_CERT_PATH='$HOME/.config/topaz/certs/grpc-ca.crt'
+ASERTO_DIRECTORY_GRPC_CERT_PATH='$HOME/.local/share/topaz/certs/grpc-ca.crt'
 ```
 
 ### Install dependencies

--- a/docs/getting-started/samples/node.mdx
+++ b/docs/getting-started/samples/node.mdx
@@ -15,7 +15,7 @@ yarn
 ```
 
 ## Set up an `.env` file
-Copy the `.env.example` file to `.env` and update the `ASERTO_AUTHORIZER_CERT_PATH` to correspond to the path in which Topaz generated your certificates (by default this path will be `$HOME/.config/topaz/certs/grpc-ca.crt`).
+Copy the `.env.example` file to `.env` and update the `ASERTO_AUTHORIZER_CERT_PATH` to correspond to the path in which Topaz generated your certificates (by default this path will be `$HOME/.local/share/topaz/certs/grpc-ca.crt`, or `$HOME\AppData\Local\topaz\certs` on Windows).
 `ASERTO_DIRECTORY_REJECT_UNAUTHORIZED=false` will let you connect to a local directory without passing the certificate.
 
 ```bash
@@ -32,7 +32,7 @@ AUDIENCE=citadel-app
 ASERTO_POLICY_ROOT=todoApp
 
 ASERTO_AUTHORIZER_SERVICE_URL=localhost:8282
-ASERTO_AUTHORIZER_CERT_PATH=$HOME/.config/topaz/certs/grpc-ca.crt
+ASERTO_AUTHORIZER_CERT_PATH=$HOME/.local/share/topaz/certs/grpc-ca.crt
 ASERTO_DIRECTORY_SERVICE_URL=localhost:9292
 ASERTO_DIRECTORY_REJECT_UNAUTHORIZED=false
 ```

--- a/docs/getting-started/samples/rails.mdx
+++ b/docs/getting-started/samples/rails.mdx
@@ -16,7 +16,7 @@ bundle install
 ```
 
 ## Set up an `.env` file
-Copy the `.env.example` file to `.env` and update the `ASERTO_AUTHORIZER_CERT_PATH` and `ASERTO_DIRECTORY_GRPC_CERT_PATH` to correspond to the path in which Topaz generated your certificates (by default this path will be `$HOME/.config/topaz/certs/grpc-ca.crt`).
+Copy the `.env.example` file to `.env` and update the `ASERTO_AUTHORIZER_CERT_PATH` and `ASERTO_DIRECTORY_GRPC_CERT_PATH` to correspond to the path in which Topaz generated your certificates (by default this path will be `$HOME/.local/share/topaz/certs/grpc-ca.crt`, or `$HOME\AppData\Local\topaz\certs` on Windows).
 
 ```bash
 cp .env.example .env
@@ -32,9 +32,9 @@ AUDIENCE=citadel-app
 ASERTO_POLICY_ROOT="todoApp"
 
 ASERTO_AUTHORIZER_SERVICE_URL=localhost:8282
-ASERTO_AUTHORIZER_CERT_PATH=$HOME/.config/topaz/certs/grpc-ca.crt
+ASERTO_AUTHORIZER_CERT_PATH=$HOME/.local/share/topaz/certs/grpc-ca.crt
 ASERTO_DIRECTORY_SERVICE_URL=localhost:9292
-ASERTO_DIRECTORY_GRPC_CERT_PATH=$HOME/.config/topaz/certs/grpc-ca.crt
+ASERTO_DIRECTORY_GRPC_CERT_PATH=$HOME/.local/share/topaz/certs/grpc-ca.crt
 ```
 
 ### Run the DB migration

--- a/docs/policies/lifecycle.mdx
+++ b/docs/policies/lifecycle.mdx
@@ -115,10 +115,10 @@ For a complete reference on the `policy` CLI, refer to the [policy CLI](/docs/co
 
 ### Run
 
-To run Topaz with the policy image, you first need to ensure the Topaz configuration file contains a reference to the policy. You can do this via the `topaz configure` command:
+To run Topaz with the policy image, you first need to ensure the Topaz configuration file contains a reference to the policy. You can do this via the `topaz config new` command:
 
 ```bash
-topaz configure -d -r my-org/my-policy:v0.1.2 -n my-policy
+topaz config new -d -r my-org/my-policy:v0.1.2 -n my-policy
 ```
 
 To start Topaz interactively:

--- a/docs/software-development-kits/java/authorizer.mdx
+++ b/docs/software-development-kits/java/authorizer.mdx
@@ -35,7 +35,7 @@ ManagedChannel channel = new ChannelBuilder()
 AuthorizerClient authzClient =  new AuthzClient(channel);
 ```
 
-If you are using Topaz as an authorizer, the certificate is located at `~/.config/topaz/certs/grpc-ca.crt`
+If you are using Topaz as an authorizer, by default the certificate will in be `$HOME/.local/share/topaz/certs/grpc-ca.crt`, or `$HOME\AppData\Local\topaz\certs` on Windows.
 For dev/test scenarios  you can also use an insecure connection by replacing `.withCACertPath(<path_to_authorizer_certificates>)` with `.withInsecure(true)`
 
 The `ChannelBuilder` accepts setting the fallowing properties:

--- a/docs/software-development-kits/java/middleware.mdx
+++ b/docs/software-development-kits/java/middleware.mdx
@@ -129,7 +129,7 @@ aserto.authorizer.decision=allowed
 ## Topaz
 ##  This configuration targets a Topaz instance running locally.
 aserto.authorizer.insecure=false
-aserto.authorizer.grpc.caCertPath=${user.home}/.config/topaz/certs/grpc-ca.crt
+aserto.authorizer.grpc.caCertPath=${user.home}/.local/share/topaz/certs/grpc-ca.crt
 
 ## Aserto hosted authorizer
 #aserto.tenantId=<tenant_id>

--- a/docs/software-development-kits/javascript/express.mdx
+++ b/docs/software-development-kits/javascript/express.mdx
@@ -64,7 +64,7 @@ import { Authorizer } from "@aserto/aserto-node";
 
 const authClient = new Authorizer({
   authorizerServiceUrl: "localhost:8282",
-  authorizerCertFile: `${process.env.HOME}/.config/topaz/certs/grpc-ca.crt`
+  authorizerCertFile: `${process.env.HOME}/.local/share/topaz/certs/grpc-ca.crt`
 });
 ```
 
@@ -80,7 +80,7 @@ import {
 const authClient = new Authorizer(
   {
     authorizerServiceUrl: "localhost:8282",
-    authorizerCertFile: `${process.env.HOME}/.config/topaz/certs/grpc-ca.crt`
+    authorizerCertFile: `${process.env.HOME}/.local/share/topaz/certs/grpc-ca.crt`
   },
 );
 
@@ -436,7 +436,7 @@ import { DirectoryServiceV3 } from "@aserto/aserto-node";
 
 const directoryClient = DirectoryServiceV3({
   url: 'localhost:9292',
-  caFile: `${process.env.HOME}/.config/topaz/certs/grpc-ca.crt`
+  caFile: `${process.env.HOME}/.local/share/topaz/certs/grpc-ca.crt`
 });
 
 - `url`: hostname:port of directory service (_required_)
@@ -886,7 +886,7 @@ Passing in the `resourceMapper` parameter into the `is()` function will override
 
 The Topaz [authorizer](/docs/authorizer-guide/overview) exposes SSL-only endpoints. In order for a Node.js policy to properly communicate with the authorizer, TLS certificates must be verified.
 
-In order for the `aserto-node` package to perform the TLS handshake, it needs to verify the TLS certificate of the Topaz authorizer using the certificate of the CA that signed it - which was placed in `$HOME/.config/topaz/certs/grpc-ca.crt`. Therefore, in order for this middleware to work successfully, either the `authorizerCertCAFile` must be set to the correct path for the CA cert file, or the `disableTlsValidation` flag must be set to `true`.
+In order for the `aserto-node` package to perform the TLS handshake, it needs to verify the TLS certificate of the Topaz authorizer using the certificate of the CA that signed it - which was placed in `$HOME/.local/share/topaz/certs/grpc-ca.crt`. Therefore, in order for this middleware to work successfully, either the `authorizerCertCAFile` must be set to the correct path for the CA cert file, or the `disableTlsValidation` flag must be set to `true`.
 
 Furthermore, when packaging a policy for deployment (e.g. in a Docker container) which uses `aserto-node` to communicate with an authorizer that has a self-signed TLS certificate, you must copy this CA certificate into the container as part of the Docker build (typically performed in the Dockerfile). When you do that, you'll need to override the `authorizerCertCAFile` option that is passed into any of the API calls defined above with the location of this cert file.
 

--- a/docs/software-development-kits/python/options.mdx
+++ b/docs/software-development-kits/python/options.mdx
@@ -45,9 +45,9 @@ All endpoints of the Topaz [Authorizer](/docs/authorizer-guide/overview) use TLS
 with the authorizer, certificates must be verified.
 
 In a development environment, Topaz automatically creates a set of self-signed certificates and certificates of the CA
-(certificate authority) that signed them. It places them in a well-known location on the filesystem, defaulting to `$HOME/.config/topaz/certs/`.
+(certificate authority) that signed them. It places them in a well-known location on the filesystem, defaulting to `$HOME/.local/share/topaz/certs/grpc-ca.crt`, or `$HOME\AppData\Local\topaz\certs` on Windows.
 
 In order for the authorizer client to perform the TLS handshake, it needs to verify the TLS certificate of the one-box
 using the certificate of the CA that signed it.
-The certificate for the authorizer's REST endpoints is placed in `$HOME/.config/topaz/certs/gateway-ca.crt`.
-The certificate for the authorizer's gRPC services is placed in `$HOME/.config/topaz/certs/grpc-ca.crt`.
+The certificate for the authorizer's REST endpoints is named `gateway-ca.crt`.
+The certificate for the authorizer's gRPC services is named `grpc-ca.crt`.

--- a/static/sidecar-deployment/configmap.yaml
+++ b/static/sidecar-deployment/configmap.yaml
@@ -12,6 +12,6 @@ data:
     
     # This configuration targets a Topaz instance running locally.
     ASERTO_AUTHORIZER_SERVICE_URL=localhost:8282
-    ASERTO_AUTHORIZER_CERT_PATH='/root/.config/topaz/certs/grpc-ca.crt'
+    ASERTO_AUTHORIZER_CERT_PATH='/root/.local/share/topaz/certs/grpc-ca.crt'
     ASERTO_DIRECTORY_SERVICE_URL=localhost:9292
-    ASERTO_DIRECTORY_GRPC_CERT_PATH='/root/.config/topaz/certs/grpc-ca.crt'
+    ASERTO_DIRECTORY_GRPC_CERT_PATH='/root/.local/share/topaz/certs/grpc-ca.crt'


### PR DESCRIPTION
This PR cleans up a whole bunch of docs that have become out of date with Topaz 0.32.
* topaz directory commands (import, export, load, save, manifest) have all been moved under `topaz directory`
* topaz test has been refactored into `topaz authorizer test` and `topaz directory test`
* topaz configure has been replaced by `topaz config new`
* config, data, and template file locations have been documented and all references to the old locations has been scrubbed
* topaz templates docs have been updated
* SDK docs have been updated to refer to the new locations of the certs directory

And other things.