### PR TITLE
IDENTITY_TYPE_MANUAL + ECS deployment

### DIFF
--- a/docs/authorizer-guide/identity-context.mdx
+++ b/docs/authorizer-guide/identity-context.mdx
@@ -8,26 +8,31 @@ description: The Identity Context and how it is used
 # Identity Context
 
 When an Authorizer evaluates a policy, it receives an Identity Context from the calling application.
-The `type` property of that Identity Context instructs the Authorizer how to identify the user:
+The Identity Context instructs the Authorizer whether and how to populate the `input.user` object
+when evaluating the policy. The process of identifying the user referred to by the Identity Context
+and loading it into the `input.user` object is known as "identity resolution".
 
-- `IDENTITY_TYPE_NONE`: the policy is evaluated without a user context (`input.user` is empty)
-- `IDENTITY_TYPE_SUB`: the user context is passed in as an OAuth subject
-- `IDENTITY_TYPE_JWT`: the user context is passed in as a JWT access token
+An identity context contains two fields: `type` and `identity`.
 
-## Passing a user identity
+The `type` of an Identity Context gives callers control over the identity resolution process:
 
-In the `IDENTITY_TYPE_SUB` and `IDENTITY_TYPE_JWT` cases, the Authorizer will treat the `identity` string as a
-OAuth subject or a JWT access, respectively. In the case of a JWT access token, the Authorizer will extract the `sub` (subject) claim, whereas
-`IDENTITY_TYPE_SUB` indicates that the `identity` string already contains a subject.
+- `IDENTITY_TYPE_NONE`: the policy is evaluated without a user context (`input.user` is empty).
+  This is most commonly used to authorize anonymous requests.
+- `IDENTITY_TYPE_SUB`: the `identity` field is a user identity such as email, username, or OAuth2 subject name.
+- `IDENTITY_TYPE_JWT`: the `identity` field is a JWT access token. The authorizer extracts the `sub` (subject)
+  claim from the token and uses it as the user identity.
+- `IDENTITY_TYPE_MANUAL`: disables identity resolution. The identity context is available in the poilcy
+  as `input.identity` but `input.user` is empty.
 
-Once the Authorizer has obtained the subject, it will use it as a key and look up the user in its
-local directory instance (known as the Edge Directory Service, or EDS). It will then load the user
-object identified by the identity context and make it available to the Policy as `input.user`.
+When using `IDENTITY_TYPE_SUB` or `IDENTITY_TYPE_JWT`, a user with the given identity must exist in
+the authorizer's directory. If no such user exists, the authorizer returns an error.
 
-For a user-facing API (for example, a back-end REST API that requires a JSON Web Token (JWT)
-in the `Authorization` header), the caller will often extract the `sub` claim from the JWT and use it
-in the `identity` field. That said, the `identity` can be any key that is used by the Identity Provider
-to identify the user.
+In a user-facing API (e.g. a back-end REST API that requires a JWT in the `Authorization` header),
+the token is typically decoded and validated during the _authentication_ phase. The service can then
+extract the `sub` claim from the JWT and pass it to the authorizer with `IDENTITY_TYPE_SUB`.
+Alternately, the entire JWT can be forwarded to the authorizer with `IDENTITY_TYPE_JWT` but the
+authorizer would then decode and validate the token too.
+
 
 ## Setting the Identity Context
 

--- a/docs/deployment/amazon-ecs.mdx
+++ b/docs/deployment/amazon-ecs.mdx
@@ -13,10 +13,59 @@ an S3 bucket before the `topaz` container starts up.
 The [topaz config new](/docs/command-line-interface/topaz-cli/configuration) CLI command can be used to generate
 your configuration file, then it should be uploaded to a bucket location that is accessible by the `init-config` container.
 
+:::caution Note
+If you intend to access the topaz console from a browser, you need to edit the generated configuration file and set the
+`fqdn` (fully-qualified domain name) field in all services to the DNS name of the topaz instance.
+For example, if you are running the topaz container with the `topaz.example.com` DNS name, you would set the `fqdn`
+field to `topaz.example.com:<port>`. Replace `<port>` with the port number that the service is running on. By default those are 8383 for
+the authorizer and 9393 for the directory services (reader, writer, model, importer, exporter).
+:::
+
 This example attaches an EBS volume to persist the configuration, certs, and directory database.  If it does not already exist
 you may need to create
 an [IAM ECS Infrastructure Role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/infrastructure_IAM_role.html)
 to allow ECS to provision EBS volumes.
+
+## Certificates
+
+By default, topaz generates its own self-signed TLS certificates if none are provided. Those certificates are not
+trusted by browsers and prevent the topaz console from communicating with the service.
+There are two ways around it:
+
+### Trust the self-signed certificates
+
+You can download the generated certificate from the topaz instance using a browser or from the terminal using `openssl`:
+
+```shell
+openssl s_client -showcerts -connect <topaz_hostname>:8383 </dev/null 2>/dev/null | \
+	openssl x509 -text > topaz-gateway.crt
+```
+
+This downloads the certificate from the specified topaz instance address and saves it to a local file
+named `topaz-gateway.crt`. You can then add the certificate to your system's trust store.
+
+To download the gRPC certificate, replace the port number with 8282:
+
+```shell
+openssl s_client -showcerts -connect <topaz_hostname>:8282 </dev/null 2>/dev/null | \
+	openssl x509 -text > topaz-grpc.crt
+```
+
+### Use your own certificates
+
+You can issue your own certificates and mount them into the `/data/certs` directory in the topaz container.
+There should be two certificates, one used for by the gRPC services and the other for REST.
+
+You should have six files in total:
+
+* `grpc.key`: private key for the gRPC services
+* `grpc.crt`: public certificate for the gRPC services
+* `grpc-ca.crt`: CA certificate for the gRPC services
+* `gateway.key`: private key for the REST services
+* `gateway.crt`: public certificate for the REST services
+* `gateway-ca.crt`: CA certificate for the REST services
+
+
 
 ### Sample task definition for topaz on Amazon ECS
 Using the ECS console, create a task definition with existing JSON.  You will need to modify the init container


### PR DESCRIPTION
* Document IDNENTITY_TYPE_MANUAL
* Instructions for configuring the console and certs in ECS deployments.